### PR TITLE
#4 Requirements met

### DIFF
--- a/BasicAVPlayer/PlayerView.swift
+++ b/BasicAVPlayer/PlayerView.swift
@@ -36,6 +36,17 @@ public class PlayerView: UIView {
         player?.play()
         
     }
+    public func printCurrentVideoPlayheadPosition(timeValue: Int64 = 1, timeScale: Int32 = 2) {
+
+        let interval = CMTime(value: timeValue, timescale: timeScale)
+        player?.addPeriodicTimeObserver(forInterval: interval,
+                                        queue: DispatchQueue.main,
+                                        using: { (progressTime) in
+            let seconds = CMTimeGetSeconds(progressTime)
+            let formattedSeconds = String(format: "%.2f", seconds)
+                print("\nSeconds: \(formattedSeconds)")
+        })
+    }
     public func subscribeToCurrentVideoStatus() {
         
         player?

--- a/VideoPlayer_UIKit_Framework/ViewController.swift
+++ b/VideoPlayer_UIKit_Framework/ViewController.swift
@@ -16,6 +16,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         addPlayerView()
+        displayPlayTimeStamps()
         displayCurrentVideoStatus()
     }
 
@@ -34,6 +35,12 @@ class ViewController: UIViewController {
         view.addSubview(containerView)
         containerView.frame = view.frame
     }
+    
+    func displayPlayTimeStamps() {
+        print("Current Playback Seconds")
+        if let playerView {
+            playerView.printCurrentVideoPlayheadPosition()
+        }
     }
     
     func displayCurrentVideoStatus() {


### PR DESCRIPTION
Added two parameters to provide those in the calling function for the consumer to make it little bit customizable.

Things learned about CMTime() and always listening to this observer on `main thread`